### PR TITLE
Minor improvements

### DIFF
--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -28,7 +28,7 @@ namespace data {
 
 	std::shared_ptr<RawObject> RawObject::Adopt(const PATH& p, const void* data, size_t length){
 		if (length == 0) { return MakeEmpty(); }
-		return std::shared_ptr<RawObject>(new RawObject(p, data, length));
+		return std::make_shared<RawObject>(p, data, length);
 	}
 
 	std::shared_ptr<RawObject> RawObject::Copy(const PATH& p, const void* data, size_t length) {

--- a/src/Data.h
+++ b/src/Data.h
@@ -15,8 +15,8 @@ namespace data {
 	public:
 		//Shared Pointer interface implementation
 		std::shared_ptr<RawObject> GetPtr() { return shared_from_this(); }
-		[[nodiscard]] static std::shared_ptr<RawObject> Create() { return std::shared_ptr<RawObject>(new RawObject()); }
-		[[nodiscard]] static std::shared_ptr<RawObject> Create(const PATH p, const void* data, const size_t size) { return std::shared_ptr<RawObject>(new RawObject(p, data, size)); }
+		[[nodiscard]] static std::shared_ptr<RawObject> Create() { return std::make_shared<RawObject>(); }
+		[[nodiscard]] static std::shared_ptr<RawObject> Create(const PATH& p, const void* data, const size_t size) { return std::make_shared<RawObject>(p, data, size); }
 
 		//Create data from file path.
 		static std::shared_ptr<RawObject> LoadFile(const PATH& p);
@@ -36,11 +36,11 @@ namespace data {
 		inline void SetPath(const PATH& p){ _path = p; }
 		//uint8 byte for easy offset.
 		inline const char* GetBytes() const
-			{ return reinterpret_cast<const char*>(_data); }
+			{ return static_cast<const char*>(_data); }
 		inline size_t size() const { return _size; }
 	private:
 		RawObject() = default;
-		RawObject(const PATH p, const void* data, const size_t size)
+		RawObject(const PATH& p, const void* data, const size_t size)
 			:_path(p), _data(data), _size(size) {}
 		const void* _data = nullptr;
 		PATH _path = PATH();


### PR DESCRIPTION
Data.h:
- Use std::make_shared to create smart pointers: fewer allocations, better exception safety and optimizations
- Changed reinterpret_cast to static_cast (line 39)
- Redefined const PATH p variable as a reference (line 19 and 43), this slightly increases performance

Data.cpp:
- Use std::make_shared to create smart pointers: fewer allocations, better exception safety and optimizations